### PR TITLE
Add --auto-servernum argument to xvfb to fix error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,8 @@ jobs:
 
     - name: Build CV (PDF)
       run: |
-        xvfb-run -- make pdf
-        xvfb-run -- make pdf_es
+        xvfb-run --auto-servernum make pdf
+        xvfb-run --auto-servernum make pdf_es
 
     - name: Build CV (HTML)
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,9 @@ jobs:
 
     - name: Build CV (pdf and html)
       run: |
-        xvfb-run -- make pdf
-        xvfb-run -- make pdf_es
-        xvfb-run -- make html
+        xvfb-run --auto-servernum make pdf
+        xvfb-run --auto-servernum make pdf_es
+        xvfb-run --auto-servernum make html
 
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@releases/v3


### PR DESCRIPTION
GitHub Actions sometimes was failing due to an error raised by xvfb. The
solution can be found here:
https://stackoverflow.com/questions/49020116/xvfb-failed-to-start-when-running-second-screen